### PR TITLE
:wrench: Update .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 image: ubuntu:latest
 
 variables:
-  REPO_SOURCE: "JunzhouLiu/BILIBILI-HELPER-PRE" # Expect to be at GitHub
+  REPO_SOURCE: "Oreomeow/bili" # Expect to be at GitHub
   PACK_NAME: "BILIBILI-HELPER"
   VERSION: "" # Tag names from https://github.com/JunzhouLiu/BILIBILI-HELPER-PRE/tags or "latest" to use the latest commit
   USE_MAVEN: "" # "TRUE" to force packing using maven when running


### PR DESCRIPTION
`JunzhouLiu/BILIBILI-HELPER-PRE` 仓库已失效，替换为 `Oreomeow/bili`